### PR TITLE
Add toggleterm repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This plugin is an evolution of my previous setup which you can find
 
 ## What is a code cell?
 A code cell is any code between a cell marker, usually a specially designated comment
-and the next cell marker or the end of the buffer. The first line of a buffer has an 
+and the next cell marker or the end of the buffer. The first line of a buffer has an
 implicit cell marker before it.
 
 For example here are a bunch of cells on a Python script
@@ -61,7 +61,8 @@ be run (just by smashing `x`) or for less commonly used functionality.
   },
   dependencies = {
     "echasnovski/mini.comment",
-    "hkupty/iron.nvim",
+    "hkupty/iron.nvim", -- repl provider
+    -- or "akinsho/toggleterm.nvim" -- repl provider
     "anuvyklack/hydra.nvim",
   },
   event = "VeryLazy",
@@ -114,12 +115,17 @@ Any options that are not specified when calling `setup` will take on their defau
     add_cell_before = "a",
     add_cell_after = "b",
   },
+  -- The repl plugin with which to interface
+  -- Current options: "iron" for iron.nvim, "toggleterm" for toggleterm.nvim,
+  -- or "auto" which checks which of the above are installed
+  repl_provider = "auto",
 }
 ```
 
 ## Dependencies
-The only hard dependency is on `iron.nvim` which provides the REPL, although
-support for others like `conjure` or `yarepl` may be added if people want them
+The only REPL options are currently `iron.nvim` or `toggleterm.nvim` which are automatically detected
+if installed.
+Support for others like `conjure` or `yarepl` may be added if people want them
 or are willing to send in PRs.
 
 Commenting cells of code depends on an external plugin. Either

--- a/doc/NotebookNavigator.txt
+++ b/doc/NotebookNavigator.txt
@@ -116,6 +116,10 @@ Default values:
           add_cell_before = "a",
           add_cell_after = "b",
       },
+      -- The repl plugin with which to interface
+      -- Current options: "iron" for iron.nvim, "toggleterm" for toggleterm.nvim,
+      -- or "auto" which checks which of the above are installed
+      repl_provider = "auto",
   }
 <
 

--- a/lua/notebook-navigator/core.lua
+++ b/lua/notebook-navigator/core.lua
@@ -1,5 +1,5 @@
-local _, iron = pcall(require, "iron.core")
 local commenter = require "notebook-navigator.commenters"
+local get_repl = require "notebook-navigator.repls"
 
 local M = {}
 
@@ -48,7 +48,9 @@ M.move_cell = function(dir, cell_marker)
   return result
 end
 
-M.run_cell = function(cell_marker)
+M.run_cell = function(cell_marker, repl_provider, repl_args)
+  repl_args = repl_args or nil
+  repl_provider = repl_provider or "auto"
   local cell_object = M.miniai_spec("i", cell_marker)
 
   -- protect ourselves against the case with no actual lines of code
@@ -57,13 +59,12 @@ M.run_cell = function(cell_marker)
     return nil
   end
 
-  local lines = vim.api.nvim_buf_get_lines(0, cell_object.from.line - 1, cell_object.to.line, 0)
-
-  iron.send(nil, lines)
+  local repl = get_repl(repl_provider)
+  repl(cell_object.from.line, cell_object.to.line, repl_args)
 end
 
-M.run_and_move = function(cell_marker)
-  M.run_cell(cell_marker)
+M.run_and_move = function(cell_marker, repl_provider, repl_args)
+  M.run_cell(cell_marker, repl_provider, repl_args)
   local is_last_cell = M.move_cell("d", cell_marker) == "last"
 
   -- insert a new cell to replicate the behaviour of jupyter notebooks

--- a/lua/notebook-navigator/init.lua
+++ b/lua/notebook-navigator/init.lua
@@ -33,6 +33,7 @@
 local M = {}
 
 local got_iron, _ = pcall(require, "iron.core")
+local got_toggleterm, _ = pcall(require, "toggleterm")
 local got_hydra, hydra = pcall(require, "hydra")
 
 local core = require "notebook-navigator.core"
@@ -70,13 +71,13 @@ end
 
 --- Run the current cell under the cursor
 M.run_cell = function()
-  core.run_cell(cell_marker())
+  core.run_cell(cell_marker(), M.config.repl_provider)
 end
 
 --- Run the current cell under the cursor and jump to next cell. If no next cell
 --- is available it will create one like Jupyter notebooks.
 M.run_and_move = function()
-  core.run_and_move(cell_marker())
+  core.run_and_move(cell_marker(), M.config.repl_provider)
 end
 
 --- Comment all the contents of the cell under the cursor
@@ -188,6 +189,10 @@ M.config = {
     add_cell_before = "a",
     add_cell_after = "b",
   },
+  -- The repl plugin with which to interface
+  -- Current options: "iron" for iron.nvim, "toggleterm" for toggleterm.nvim,
+  -- or "auto" which checks which of the above are installed
+  repl_provider = "auto",
 }
 --minidoc_afterlines_end
 
@@ -228,8 +233,8 @@ M.setup = function(config)
     vim.notify "[NotebookNavigator] Hydra is not available.\nHydra will not be available."
   end
 
-  if not got_iron then
-    vim.notify "[NotebookNavigator] Iron is not available.\nMost functionality will error out."
+  if not got_iron and not got_toggleterm then
+    vim.notify "[NotebookNavigator] REPL is not available.\nMost functionality will error out."
   end
 
   if (M.config.activate_hydra_keys ~= nil) and got_hydra then

--- a/lua/notebook-navigator/repls.lua
+++ b/lua/notebook-navigator/repls.lua
@@ -1,0 +1,56 @@
+local repls = {}
+
+-- iron.nvim
+repls.iron = function(start_line, end_line, repl_args)
+  local lines = vim.api.nvim_buf_get_lines(0, start_line-1, end_line, 0)
+  require("iron.core").send(nil, lines)
+end
+
+-- toggleterm
+repls.toggleterm = function(start_line, end_line, repl_args)
+  local id = 1
+  local trim_spaces = true
+  if repl_args then
+    id = repl_args.id or 1
+    trim_spaces = repl_args.trim_spaces or true
+  end
+  local current_window = vim.api.nvim_get_current_win()
+  local lines = vim.api.nvim_buf_get_lines(0, start_line-1, end_line, 0)
+
+  if not lines or not next(lines) then return end
+
+  for _, line in ipairs(lines) do
+    local l = trim_spaces and line:gsub("^%s+", ""):gsub("%s+$", "") or line
+    require("toggleterm").exec(l, id)
+  end
+
+  -- Jump back with the cursor where we were at the beginning of the selection
+  local cursor_line, cursor_col = unpack(vim.api.nvim_win_get_cursor(0))
+  vim.api.nvim_set_current_win(current_window)
+
+  vim.api.nvim_win_set_cursor(current_window, { cursor_line, cursor_col })
+end
+
+-- no repl
+repls.no_repl = function(_) end
+
+local get_repl = function(repl_provider)
+  local repl_providers = { "iron", "toggleterm" }
+  if repl_provider == "auto" then
+    for _, r in ipairs(repl_providers) do
+      if pcall(require, r) then
+        return repls[r]
+      end
+      vim.notify "[Notebook Navigator] None of the supported REPL providers is available. Please install iron or toggleterm"
+    end
+  else
+    if pcall(require, repl_provider) then
+      return repls[repl_provider]
+    else
+      vim.notify("[Notebook Navigator] The " .. repl_provider .. " REPL provider is not available.")
+    end
+  end
+  return repls["no_repl"]
+end
+
+return get_repl


### PR DESCRIPTION
This PR establishes a format for adding more repl providers than just `iron.nvim` and adds `toggleterm.nvim` as an example. Addresses #2.

Mirrors the idea of the various commenters by searching for installed `iron` or `toggleterm` rather than adding a new configuration option. Seemed more convenient. However, it is possible that someone has both installed and wants to select the repl..