### PR TITLE
Cell highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ be run (just by smashing `x`) or for less commonly used functionality.
   },
   dependencies = {
     "echasnovski/mini.comment",
+    "echasnovski/mini.hipatterns",
     "hkupty/iron.nvim", -- repl provider
     -- or "akinsho/toggleterm.nvim" -- repl provider
     "anuvyklack/hydra.nvim",
@@ -79,14 +80,24 @@ Just add it to the custom_textobjects and of you are off to the races!
 
 All you need is to add the textobject specification to the 'mini.ai' `custom_textobjects`
 
+You can also use the `minihipatterns_spec` function to add line highlighting to cell markers.
+
 ```lua
 local nn = require "notebook-navigator"
 local ai = require "mini.ai"
+local hi = require "mini.hipatterns"
 
 ai.setup(
   {
     custom_textobjects = {
       h = nn.miniai_spec,
+    },
+  }
+)
+hi.setup(
+  {
+    highlighters = {
+      cells = nn.minihipatterns_spec,
     },
   }
 )
@@ -99,8 +110,6 @@ Any options that are not specified when calling `setup` will take on their defau
   -- Code cell marker. Cells start with the marker and end either at the beginning
   -- of the next cell or at the end of the file.
   cell_markers = { python = "# %%", lua = "-- %%", julia = "# %%", fennel = ";; %%" },
-  -- If not `nil`, cell markers will be highlighted
-  cell_highlight_group = "CursorLineNr",
   -- If not `nil` the keymap defined in the string will activate the hydra head.
   -- If you don't want to use hydra you don't need to install it either.
   activate_hydra_keys = nil,
@@ -121,6 +130,8 @@ Any options that are not specified when calling `setup` will take on their defau
   -- Current options: "iron" for iron.nvim, "toggleterm" for toggleterm.nvim,
   -- or "auto" which checks which of the above are installed
   repl_provider = "auto",
+  -- (Optional) for use with `mini.hipatterns` to highlight cell markers
+  cell_highlight_group = "CursorLineNr",
 }
 ```
 
@@ -135,10 +146,12 @@ Commenting cells of code depends on an external plugin. Either
 [mini.comment](https://github.com/echasnovski/mini.comment) the two most
 popular choices by quite a bit. If you want support for more PRs are welcome.
 
-Finally, 'mini.ai' is not a dependency but if you want to use the provided
+'mini.ai' is not a dependency but if you want to use the provided
 textobject specification (highly recommended) you will then need to have it
 installed.
 
+Finally, 'mini.hipatterns' is also not a dependency but can provide line
+highlighting to distinguish cell markers from the rest of the text.
 
 ## Yanking/Deleting cells
 If you setup the mini.ai integration (see below) you can then do things like,

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Any options that are not specified when calling `setup` will take on their defau
   -- or "auto" which checks which of the above are installed
   repl_provider = "auto",
   -- (Optional) for use with `mini.hipatterns` to highlight cell markers
-  cell_highlight_group = "CursorLineNr",
+  cell_highlight_group = "Folded",
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This plugin is an evolution of my previous setup which you can find
 
 ## What is a code cell?
 A code cell is any code between a cell marker, usually a specially designated comment
-and the next cell marker or the end of the buffer. The first line of a buffer has an 
+and the next cell marker or the end of the buffer. The first line of a buffer has an
 implicit cell marker before it.
 
 For example here are a bunch of cells on a Python script
@@ -98,6 +98,8 @@ Any options that are not specified when calling `setup` will take on their defau
   -- Code cell marker. Cells start with the marker and end either at the beginning
   -- of the next cell or at the end of the file.
   cell_markers = { python = "# %%", lua = "-- %%", julia = "# %%", fennel = ";; %%" },
+  -- If not `nil`, cell markers will be highlighted
+  cell_highlight_group = "CursorLineNr",
   -- If not `nil` the keymap defined in the string will activate the hydra head.
   -- If you don't want to use hydra you don't need to install it either.
   activate_hydra_keys = nil,

--- a/doc/NotebookNavigator.txt
+++ b/doc/NotebookNavigator.txt
@@ -102,8 +102,6 @@ Default values:
       -- Code cell marker. Cells start with the marker and end either at the beginning
       -- of the next cell or at the end of the file.
       cell_markers = { python = "# %%", lua = "-- %%", julia = "# %%", fennel = ";; %%" },
-      -- If not `nil`, cell markers will be highlighted
-      cell_highlight_group = "CursorLineNr",
       -- If not `nil` the keymap defined in the string will activate the hydra head
       -- If you don't want to use hydra you don't need to install it either.
       activate_hydra_keys = nil,
@@ -124,6 +122,8 @@ Default values:
       -- Current options: "iron" for iron.nvim, "toggleterm" for toggleterm.nvim,
       -- or "auto" which checks which of the above are installed
       repl_provider = "auto",
+      -- (Optional) for use with `mini.hipatterns` to highlight cell markers
+      cell_highlight_group = "CursorLineNr",
   }
 <
 

--- a/doc/NotebookNavigator.txt
+++ b/doc/NotebookNavigator.txt
@@ -121,7 +121,7 @@ Default values:
     -- or "auto" which checks which of the above are installed
     repl_provider = "auto",
     -- (Optional) for use with `mini.hipatterns` to highlight cell markers
-    cell_highlight_group = "CursorLineNr",
+    cell_highlight_group = "Folded",
   }
 <
 

--- a/doc/NotebookNavigator.txt
+++ b/doc/NotebookNavigator.txt
@@ -102,9 +102,13 @@ Default values:
       -- Code cell marker. Cells start with the marker and end either at the beginning
       -- of the next cell or at the end of the file.
       cell_markers = { python = "# %%", lua = "-- %%", julia = "# %%", fennel = ";; %%" },
+      -- If not `nil`, cell markers will be highlighted
+      cell_highlight_group = "CursorLineNr",
       -- If not `nil` the keymap defined in the string will activate the hydra head
+      -- If you don't want to use hydra you don't need to install it either.
       activate_hydra_keys = nil,
-      -- If `true` a hint panel will be shown when the hydra head is active
+      -- If `true` a hint panel will be shown when the hydra head is active. If `false`
+      -- you get a minimalistic hint on the command line.
       show_hydra_hint = true,
       -- Mappings while the hydra head is active.
       hydra_keys = {

--- a/lua/notebook-navigator/core.lua
+++ b/lua/notebook-navigator/core.lua
@@ -28,6 +28,19 @@ M.miniai_spec = function(opts, cell_marker)
   return { from = from, to = to }
 end
 
+M.all_cell_positions = function(cell_marker)
+  local vim_cmd = vim.api.nvim_parse_cmd("ilist! /^"..cell_marker.."/", {})
+  vim_cmd.args = {table.concat(vim_cmd.args, " ")} -- Fix space in args (if multiple)
+  local has_output, cmd_output = pcall(vim.api.nvim_cmd, vim_cmd, {output=true})
+  local cell_lines = {}
+  if has_output then
+    for k,_ in string.gmatch(cmd_output, "%s%d+%s") do
+      table.insert(cell_lines,tonumber(k))
+    end
+  end
+  return cell_lines
+end
+
 M.move_cell = function(dir, cell_marker)
   local search_res
   local result

--- a/lua/notebook-navigator/highlight.lua
+++ b/lua/notebook-navigator/highlight.lua
@@ -2,13 +2,18 @@ local core = require "notebook-navigator.core"
 
 local highlight = {}
 
-function highlight.highlight_cells(cell_marker, hl_group)
+function highlight.highlight_cell_markers(cell_marker, hl_group, ns)
   local cell_lines = core.all_cell_positions(cell_marker)
-  local ns_id = vim.api.nvim_create_namespace('cells')
-  vim.api.nvim_buf_clear_namespace(0,ns_id,0,-1)
+  vim.api.nvim_buf_clear_namespace(0,ns,0,-1)
   for _,line in ipairs(cell_lines) do
-      vim.api.nvim_buf_set_extmark(0,ns_id,line-1,-1,{hl_eol=true,line_hl_group=hl_group})
+    highlight.highlight_cell_marker(line, hl_group, ns)
   end
+  return cell_lines
+end
+
+function highlight.highlight_cell_marker(line, hl_group, ns)
+    local ext_opts = {hl_eol=true,line_hl_group=hl_group}
+    vim.api.nvim_buf_set_extmark(0, ns, line-1, -1, ext_opts)
 end
 
 return highlight

--- a/lua/notebook-navigator/highlight.lua
+++ b/lua/notebook-navigator/highlight.lua
@@ -15,7 +15,13 @@ highlight.minihipatterns_spec = function(cell_markers, hl_group)
          end
       end,
       group = '',
-      extmark_opts = { line_hl_group = hl_group, hl_eol = true}
+      extmark_opts = {
+        virt_text = {
+          {"───────────────────────────────────────────────────────────────", hl_group},
+        },
+        line_hl_group = hl_group,
+        hl_eol = true,
+      }
     }
   return notebook_cells
 end

--- a/lua/notebook-navigator/highlight.lua
+++ b/lua/notebook-navigator/highlight.lua
@@ -2,18 +2,22 @@ local core = require "notebook-navigator.core"
 
 local highlight = {}
 
-function highlight.highlight_cell_markers(cell_marker, hl_group, ns)
-  local cell_lines = core.all_cell_positions(cell_marker)
-  vim.api.nvim_buf_clear_namespace(0,ns,0,-1)
-  for _,line in ipairs(cell_lines) do
-    highlight.highlight_cell_marker(line, hl_group, ns)
-  end
-  return cell_lines
-end
-
-function highlight.highlight_cell_marker(line, hl_group, ns)
-    local ext_opts = {hl_eol=true,line_hl_group=hl_group}
-    vim.api.nvim_buf_set_extmark(0, ns, line-1, -1, ext_opts)
+highlight.minihipatterns_spec = function(cell_markers, hl_group)
+  local notebook_cells = {
+      pattern = function(buf_id)
+        local buf_ft = vim.bo[buf_id].filetype
+          local cell_marker = cell_markers[buf_ft]
+          if cell_marker then
+            local regex_cell_marker = string.gsub("^"..cell_marker, "%%", "%%%%")
+            return regex_cell_marker
+         else
+           return nil
+         end
+      end,
+      group = '',
+      extmark_opts = { line_hl_group = hl_group, hl_eol = true}
+    }
+  return notebook_cells
 end
 
 return highlight

--- a/lua/notebook-navigator/highlight.lua
+++ b/lua/notebook-navigator/highlight.lua
@@ -1,0 +1,14 @@
+local core = require "notebook-navigator.core"
+
+local highlight = {}
+
+function highlight.highlight_cells(cell_marker, hl_group)
+  local cell_lines = core.all_cell_positions(cell_marker)
+  local ns_id = vim.api.nvim_create_namespace('cells')
+  vim.api.nvim_buf_clear_namespace(0,ns_id,0,-1)
+  for _,line in ipairs(cell_lines) do
+      vim.api.nvim_buf_set_extmark(0,ns_id,line-1,-1,{hl_eol=true,line_hl_group=hl_group})
+  end
+end
+
+return highlight

--- a/lua/notebook-navigator/init.lua
+++ b/lua/notebook-navigator/init.lua
@@ -36,6 +36,7 @@ local got_iron, _ = pcall(require, "iron.core")
 local got_hydra, hydra = pcall(require, "hydra")
 
 local core = require "notebook-navigator.core"
+local highlight = require "notebook-navigator.highlight"
 local utils = require "notebook-navigator.utils"
 
 local cell_marker = function()
@@ -174,6 +175,8 @@ M.config = {
   -- Code cell marker. Cells start with the marker and end either at the beginning
   -- of the next cell or at the end of the file.
   cell_markers = { python = "# %%", lua = "-- %%", julia = "# %%", fennel = ";; %%" },
+  -- If not `nil`, cell markers will be highlighted
+  cell_highlight_group = "CursorLineNr",
   -- If not `nil` the keymap defined in the string will activate the hydra head
   activate_hydra_keys = nil,
   -- If `true` a hint panel will be shown when the hydra head is active
@@ -234,6 +237,17 @@ M.setup = function(config)
 
   if (M.config.activate_hydra_keys ~= nil) and got_hydra then
     activate_hydra(M.config)
+  end
+
+  vim.api.nvim_create_augroup("NotebookNavigator", {clear=true})
+  if (M.config.cell_highlight_group ~= nil) then
+    local auto_cell_highlight = function()
+      local ft = vim.bo.filetype
+      if M.config.cell_markers[ft] ~= nil then
+        highlight.highlight_cells(M.config.cell_markers[ft], M.config.cell_highlight_group)
+      end
+    end
+    vim.api.nvim_create_autocmd({"BufEnter", "TextChanged", "TextChangedI"}, {group="NotebookNavigator",pattern={"*"},callback=auto_cell_highlight})
   end
 end
 

--- a/lua/notebook-navigator/init.lua
+++ b/lua/notebook-navigator/init.lua
@@ -192,8 +192,6 @@ M.config = {
   -- Code cell marker. Cells start with the marker and end either at the beginning
   -- of the next cell or at the end of the file.
   cell_markers = { python = "# %%", lua = "-- %%", julia = "# %%", fennel = ";; %%" },
-  -- If not `nil`, cell markers will be highlighted
-  cell_highlight_group = "CursorLineNr",
   -- If not `nil` the keymap defined in the string will activate the hydra head
   activate_hydra_keys = nil,
   -- If `true` a hint panel will be shown when the hydra head is active
@@ -212,6 +210,8 @@ M.config = {
   -- Current options: "iron" for iron.nvim, "toggleterm" for toggleterm.nvim,
   -- or "auto" which checks which of the above are installed
   repl_provider = "auto",
+  -- (Optional) for use with `mini.hipatterns` to highlight cell markers
+  cell_highlight_group = "Folded",
 }
 --minidoc_afterlines_end
 

--- a/lua/notebook-navigator/init.lua
+++ b/lua/notebook-navigator/init.lua
@@ -244,56 +244,9 @@ M.setup = function(config)
     activate_hydra(M.config)
   end
 
-  vim.api.nvim_create_augroup("NotebookNavigator", {clear=true})
-  if (M.config.cell_highlight_group ~= nil) then
-    local cell_ns = vim.api.nvim_create_namespace('cells')
+  --- Highlight spec for mini.hipatterns
+  M.minihipatterns_spec = highlight.minihipatterns_spec(M.config.cell_markers, M.config.cell_highlight_group)
 
-    local auto_highlight = function()
-      local cell_lines = highlight.highlight_cell_markers(cell_marker(), M.config.cell_highlight_group, cell_ns)
-      -- Note locations of markers
-      local was_marker = {}
-      for _,line_num in ipairs(cell_lines) do
-        was_marker[line_num] = true
-      end
-
-      -- Watch buffer changes for cell markers
-      vim.api.nvim_buf_attach(0, false, {
-        on_lines = function(_,_,_,start_line,_,end_line)
-          local lines = vim.api.nvim_buf_get_lines(0, start_line, end_line, 0)
-          local lua_cell_marker = "^" .. string.gsub(cell_marker(), "%%", "%%%%")
-          if lines then
-            for i,line in ipairs(lines) do
-              if string.find(line, lua_cell_marker) then
-                -- If a marker has been written -> highlight
-                highlight.highlight_cell_marker(start_line+i, M.config.cell_highlight_group, cell_ns)
-                was_marker[start_line+i] = true
-              elseif was_marker[start_line+i] then
-                -- If a marker was on this line before -> delete highlight
-                local old_marks = vim.api.nvim_buf_get_extmarks(0, cell_ns, {start_line+i-1,0}, {start_line+i,0}, {})
-                for _,mark_info in ipairs(old_marks) do
-                  vim.api.nvim_buf_del_extmark(0, cell_ns, mark_info[1])
-                end
-                was_marker[start_line+i] = false
-              else
-                -- No marker is on this line
-                was_marker[start_line+i] = false
-              end
-            end
-          end
-        end
-      })
-    end
-
-    -- Only watch buffers that have valid cell markers in config
-    vim.api.nvim_create_autocmd(
-      {"FileType"},
-      {
-        group="NotebookNavigator",
-        pattern=utils.get_valid_filetypes(M.config.cell_markers),
-        callback=auto_highlight
-      }
-    )
-  end
 end
 
 

--- a/lua/notebook-navigator/utils.lua
+++ b/lua/notebook-navigator/utils.lua
@@ -12,4 +12,12 @@ utils.get_cell_marker = function(bufnr, cell_markers)
   return cell_markers[ft]
 end
 
+utils.get_valid_filetypes = function(cell_markers)
+  local valid_filetypes = {}
+  for k,_ in pairs(cell_markers) do
+    table.insert(valid_filetypes, k)
+  end
+  return valid_filetypes
+end
+
 return utils


### PR DESCRIPTION
Addresses #8.

A few design notes for discussion:
- The highlighting is updated with all text changes and when entering a buffer. This may be a little heavier than needed and could just be changed to whenever saving?
- The highlight config option is just the group but if you set it to `nil` there won't be any highlighting (saves having two config options)
- The default highlight group I set as `CursorLineNr` because it usually gives vibrant visible text but a more subtle highlighting. Definitely could be another group though