### PR TITLE
Add links to the dependencies in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ be run (just by smashing `x`) or for less commonly used functionality.
   dependencies = {
     "echasnovski/mini.comment",
     "hkupty/iron.nvim", -- repl provider
-    -- or "akinsho/toggleterm.nvim" -- repl provider
+    -- "akinsho/toggleterm.nvim", -- alternative repl provider
     "anuvyklack/hydra.nvim",
   },
   event = "VeryLazy",

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ to `false`. See issue for more details.
 
 
 ## Dependencies
-The only REPL options are currently `iron.nvim` or `toggleterm.nvim` which are automatically detected
+The only REPL options are currently [iron.nvim](https://github.com/Vigemus/iron.nvim) or
+[toggleterm.nvim](https://github.com/akinsho/toggleterm.nvim) which are automatically detected
 if installed.
 Support for others like `conjure` or `yarepl` may be added if people want them
 or are willing to send in PRs.


### PR DESCRIPTION
It's nicer if you can directly click on them to see how they are configured instead of having to google them.

EDIT: I also tweaked the example config a bit so that one can just uncomment the `toggleterm` line and have it be syntactically correct