### PR TITLE
fix: Default marker for filetypes with % commentstring

### DIFF
--- a/lua/notebook-navigator/utils.lua
+++ b/lua/notebook-navigator/utils.lua
@@ -17,7 +17,8 @@ utils.get_cell_marker = function(bufnr, cell_markers)
   if not vim.bo.commentstring then
     error("There's no cell marker and no commentstring defined for filetype " .. ft)
   end
-  local double_percent_cell_marker = vim.bo.commentstring:format "%%"
+  local cstring = string.gsub(vim.bo.commentstring, "^%%", "%%%%")
+  local double_percent_cell_marker = cstring:format "%%"
   return double_percent_cell_marker
 end
 


### PR DESCRIPTION
I noticed that for files with `% %s` comment strings (latex, matlab, etc.), the `get_cell_marker` function would fail when trying to use `string.format` on the commentstring (because of the `%` special character). 

This PR replaces any `%` at the start of the commentstring with the escaped version `%%`prior to formatting.