### PR TITLE
New Feature: Run Cells Above

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ be run (just by smashing `x`) or for less commonly used functionality.
 {
   "ESSO0428/NotebookNavigator.nvim",
   keys = {
+    { "[e", function() require("notebook-navigator").run_cells_above "" end },
+    { "]e", function() require("notebook-navigator").run_cells_below "" end },
     { "]h", function() require("notebook-navigator").move_cell "d" end },
     { "[h", function() require("notebook-navigator").move_cell "u" end },
     { "<leader>X", "<cmd>lua require('notebook-navigator').run_cell()<cr>" },

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ available through leader keymaps but will turn to the Hydra head when many cells
 be run (just by smashing `x`) or for less commonly used functionality.
 ```lua
 {
-  "GCBallesteros/NotebookNavigator.nvim",
+  "ESSO0428/NotebookNavigator.nvim",
   keys = {
     { "]h", function() require("notebook-navigator").move_cell "d" end },
     { "[h", function() require("notebook-navigator").move_cell "u" end },
@@ -88,7 +88,7 @@ look like:
 return {
   "echasnovski/mini.hipatterns",
   event = "VeryLazy",
-  dependencies = { "GCBallesteros/NotebookNavigator.nvim" },
+  dependencies = { "ESSO0428/NotebookNavigator.nvim" },
   opts = function()
     local nn = require "notebook-navigator"
 
@@ -112,7 +112,7 @@ meant include the _code cell_ text object then your 'mini.ai' could look like:
 return {
   "echasnovski/mini.ai",
   event = "VeryLazy",
-  dependencies = { "GCBallesteros/NotebookNavigator.nvim" },
+  dependencies = { "ESSO0428/NotebookNavigator.nvim" },
   opts = function()
     local nn = require "notebook-navigator"
 

--- a/lua/notebook-navigator/core.lua
+++ b/lua/notebook-navigator/core.lua
@@ -103,6 +103,18 @@ M.run_all_cells = function(repl_provider, repl_args)
   repl(1, buf_length, repl_args)
 end
 
+M.run_cells_above = function(cell_marker, repl_provider, repl_args)
+  local start_line = 1
+  local cell_object = miniai_spec("i", cell_marker)
+
+  local repl = get_repl(repl_provider)
+
+  if cell_object.from.line > 1 then
+    local previous_cell_end = cell_object.from.line - 1
+    repl(start_line, previous_cell_end, repl_args)
+  end
+end
+
 M.run_cells_below = function(cell_marker, repl_provider, repl_args)
   local buf_length = vim.api.nvim_buf_line_count(0)
   local cell_object = miniai_spec("i", cell_marker)

--- a/lua/notebook-navigator/init.lua
+++ b/lua/notebook-navigator/init.lua
@@ -110,6 +110,13 @@ M.run_all_cells = function(repl_args)
   core.run_all_cells(M.config.repl_provider, repl_args)
 end
 
+--- Run all cells above the current cell
+---
+---@param repl_args table|nil Optional config for the repl.
+M.run_cells_above = function(repl_args)
+  core.run_cells_above(cell_marker(), M.config.repl_provider, repl_args)
+end
+
 --- Run all cells below (including current cell)
 ---
 ---@param repl_args table|nil Optional config for the repl.
@@ -207,7 +214,7 @@ local function activate_hydra(config)
       M.split_cell,
       { desc = "Split cell", nowait = true },
     },
-    { "q", nil, { exit = true, nowait = true, desc = "exit" } },
+    { "q",     nil, { exit = true, nowait = true, desc = "exit" } },
     { "<esc>", nil, { exit = true, nowait = true, desc = "exit" } },
   }
 
@@ -318,7 +325,7 @@ M.setup = function(config)
   if #utils.available_repls == 0 then
     vim.notify "[NotebookNavigator] No supported REPLs available.\nMost functionality will error out."
   elseif
-    M.config.repl_provider ~= "auto" and not utils.has_value(utils.available_repls, M.config.repl_provider)
+      M.config.repl_provider ~= "auto" and not utils.has_value(utils.available_repls, M.config.repl_provider)
   then
     vim.notify("[NotebookNavigator] The requested repl (" .. M.config.repl_provider .. ") is not available.")
   end


### PR DESCRIPTION
## New Feature: Run Cells Above

This pull request introduces a new feature `run_cells_above` to the NotebookNavigator plugin. This function allows users to execute all code cells above the current cell, which is similar to functionality seen in tools like Jupyter notebooks.


### Implementation:
- The function calculates the current cell's position and executes each cell above it.
- Utilizes the existing infrastructure for running cells but adds logic to determine the scope of execution dynamically based on the cursor's position.

### Usage:
Users can invoke this function via a command or keybinding in Neovim. Example usage might be via a mapped key in normal mode, such as below
```lua
   ...
    keys = {
      ...
      { "[e", function() require("notebook-navigator").run_cells_above "" end },
    },
   ...
```

### Request for Feedback:
Please review the implementation details and functionality. I am open to suggestions for improvements or additional scenarios that should be considered.

Looking forward to your feedback and hoping for integration into the main project!
