### PR TITLE
feat: Move the cell marker too when swapping cells

### DIFF
--- a/lua/notebook-navigator/core.lua
+++ b/lua/notebook-navigator/core.lua
@@ -26,42 +26,67 @@ end
 
 M.swap_cell = function(dir, cell_marker)
   local buf_length = vim.api.nvim_buf_line_count(0)
+  local should_insert_marker = false
 
   -- Get cells in their future order
   local starting_cursor = vim.api.nvim_win_get_cursor(0)
   local first_cell
   local second_cell
   if dir == "d" then
-    second_cell = miniai_spec("i", cell_marker)
-    if second_cell.to.line + 2 > buf_length then
+    second_cell = miniai_spec("a", cell_marker)
+    if second_cell.to.line + 1 > buf_length then
       return
     end
     vim.api.nvim_win_set_cursor(0, { second_cell.to.line + 2, 0 })
-    first_cell = miniai_spec("i", cell_marker)
+    first_cell = miniai_spec("a", cell_marker)
   else
-    first_cell = miniai_spec("i", cell_marker)
-    if first_cell.from.line - 2 < 1 then
+    first_cell = miniai_spec("a", cell_marker)
+    if first_cell.from.line - 1 < 1 then
       return
     end
-    vim.api.nvim_win_set_cursor(0, { first_cell.from.line - 2, 0 })
-    second_cell = miniai_spec("i", cell_marker)
+    vim.api.nvim_win_set_cursor(0, { first_cell.from.line - 1, 0 })
+    second_cell = miniai_spec("a", cell_marker)
+
+    -- The first cell may not have a marker. If this is the case and we attempt to
+    -- swap it down we will be in trouble. In that case we first insert a marker at
+    -- the top.
+    -- If the line does not start with the cell_marker with set a marker to add
+    -- the line later on.
+    local first_cell_line =
+      vim.api.nvim_buf_get_lines(0, second_cell.from.line - 1, second_cell.from.line, false)[1]
+
+    if string.sub(first_cell_line, 1, string.len(cell_marker)) ~= cell_marker then
+      should_insert_marker = true
+    end
+    --
   end
 
   -- Combine cells and set in place
   local first_lines = vim.api.nvim_buf_get_lines(0, first_cell.from.line - 1, first_cell.to.line, false)
   local second_lines = vim.api.nvim_buf_get_lines(0, second_cell.from.line - 1, second_cell.to.line, false)
-  table.insert(first_lines, cell_marker)
-  for _, v in ipairs(second_lines) do
-    table.insert(first_lines, v)
+
+  local final_lines = {}
+
+  for _, v in ipairs(first_lines) do
+    table.insert(final_lines, v)
   end
-  vim.api.nvim_buf_set_lines(0, second_cell.from.line - 1, first_cell.to.line, false, first_lines)
+
+  -- This extra marker protects us agains malformed notebooks that don't have a cell
+  -- marker at the top of the file. See the "up" case a few lines above.
+  if should_insert_marker then
+    table.insert(final_lines, cell_marker)
+  end
+  for _, v in ipairs(second_lines) do
+    table.insert(final_lines, v)
+  end
+  vim.api.nvim_buf_set_lines(0, second_cell.from.line - 1, first_cell.to.line, false, final_lines)
 
   -- Put cursor in previous position
   local new_cursor = starting_cursor
   if dir == "d" then
-    new_cursor[1] = new_cursor[1] + (first_cell.to.line - first_cell.from.line + 2)
+    new_cursor[1] = new_cursor[1] + (first_cell.to.line - first_cell.from.line + 1)
   else
-    new_cursor[1] = new_cursor[1] - (second_cell.to.line - second_cell.from.line + 2)
+    new_cursor[1] = new_cursor[1] - (second_cell.to.line - second_cell.from.line + 1)
   end
   vim.api.nvim_win_set_cursor(0, new_cursor)
 end


### PR DESCRIPTION
This makes it possible to add metadata next to the cell marker and keep it in the correct place when swapping. For example jupytext will add extra metadata such as `[markdown]` next to the marker to denote special cell types.