### PR TITLE
fix: MoltenEvaluateRange end_line number

### DIFF
--- a/lua/notebook-navigator/repls.lua
+++ b/lua/notebook-navigator/repls.lua
@@ -50,7 +50,17 @@ repls.molten = function(start_line, end_line, repl_args, cell_marker)
     vim.api.nvim_buf_set_lines(0, end_line + 1, end_line + 1, false, { cell_marker, "" })
   end
 
-  local ok, _ = pcall(vim.fn.MoltenEvaluateRange, start_line, end_line)
+  -- to avoid image showing in the next cell, only evaluate to last non-empty line
+  local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
+  local non_empty_end_line = nil
+  for i = #lines, 1, -1 do
+    if lines[i]:gsub("%s+", "") ~= "" then
+      non_empty_end_line = end_line - #lines + i
+      break
+    end
+  end
+
+  local ok, _ = pcall(vim.fn.MoltenEvaluateRange, start_line, non_empty_end_line)
   if not ok then
     vim.cmd "MoltenInit"
     return false

--- a/lua/notebook-navigator/repls.lua
+++ b/lua/notebook-navigator/repls.lua
@@ -50,7 +50,7 @@ repls.molten = function(start_line, end_line, repl_args, cell_marker)
     vim.api.nvim_buf_set_lines(0, end_line + 1, end_line + 1, false, { cell_marker, "" })
   end
 
-  local ok, _ = pcall(vim.fn.MoltenEvaluateRange, start_line, end_line + 1)
+  local ok, _ = pcall(vim.fn.MoltenEvaluateRange, start_line, end_line)
   if not ok then
     vim.cmd "MoltenInit"
     return false


### PR DESCRIPTION
Due to the `end_line+1` in line 53 of `reple.lua`
```lua
local ok, _ = pcall(vim.fn.MoltenEvaluateRange, start_line, end_line+1)
```
MoltenEvaluateRange always include an extra cell marker, see screenshot below
![image](https://github.com/GCBallesteros/NotebookNavigator.nvim/assets/33592421/7c09b787-6929-4bcc-a1af-828a4b019e45)

I don't think this is intended behavior. I remove the +1, and here is the fixed behavior
![image](https://github.com/GCBallesteros/NotebookNavigator.nvim/assets/33592421/88dc6990-af1f-4f8f-91a9-a0de9ccaf7b7)
