### PR TITLE
fix: remove trailing marker

### DIFF
--- a/lua/notebook-navigator/repls.lua
+++ b/lua/notebook-navigator/repls.lua
@@ -50,7 +50,7 @@ repls.molten = function(start_line, end_line, repl_args, cell_marker)
     vim.api.nvim_buf_set_lines(0, end_line + 1, end_line + 1, false, { cell_marker, "" })
   end
 
-  local ok, _ = pcall(vim.fn.MoltenEvaluateRange, start_line, end_line + 1)
+  local ok, _ = pcall(vim.fn.MoltenEvaluateRange, start_line, end_line)
   if not ok then
     vim.cmd "MoltenInit"
     return false


### PR DESCRIPTION
This commit resolves an overlooked issue with language-specific comments and introduces support for non-language-specific markers, such as Markdown code blocks.