### PR TITLE
Update hydra in suggested config to a maintained version by nvimtools. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ be run (just by smashing `x`) or for less commonly used functionality.
     "hkupty/iron.nvim", -- repl provider
     -- "akinsho/toggleterm.nvim", -- alternative repl provider
     -- "benlubas/molten-nvim", -- alternative repl provider
-    "anuvyklack/hydra.nvim",
+    "nvimtools/hydra.nvim",
   },
   event = "VeryLazy",
   config = function()

--- a/lua/notebook-navigator/init.lua
+++ b/lua/notebook-navigator/init.lua
@@ -224,7 +224,7 @@ local function activate_hydra(config)
     config = {
       invoke_on_body = true,
       color = "pink",
-      hint = { border = "rounded" },
+      hint = { float_opts = { border = "rounded" } },
     },
     body = config.activate_hydra_keys,
     heads = active_hydra_heads,


### PR DESCRIPTION
Short PR with some minor changes. Switch to nvimtools/hydra.nvim because it is still maintained and then with that switch we need to update some settings in the initlua due to a deprecation of the hint border settings. 